### PR TITLE
fix: correct LXC node assignment in getVMs

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ try {
   console.error('Warning: Could not load .env file:', error.message);
 }
 
-class ProxmoxServer {
+export class ProxmoxServer {
   constructor() {
     this.server = new Server(
       {
@@ -1171,7 +1171,7 @@ class ProxmoxServer {
         
         if (typeFilter === 'all' || typeFilter === 'lxc') {
           const nodeLXCs = await this.proxmoxRequest(`/nodes/${node.node}/lxc`);
-          vms.push(...nodeLXCs.map(vm => ({ ...vm, type: 'lxc', node: vm.node || node.node })));
+          vms.push(...nodeLXCs.map(vm => ({ ...vm, type: 'lxc', node: node.node })));
         }
       }
     }
@@ -3144,5 +3144,7 @@ class ProxmoxServer {
   }
 }
 
-const server = new ProxmoxServer();
-server.run().catch(console.error);
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = new ProxmoxServer();
+  server.run().catch(console.error);
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "dev": "node --watch index.js"
+    "dev": "node --watch index.js",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.4.0",

--- a/test/getVMs.lxc-node.test.js
+++ b/test/getVMs.lxc-node.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ProxmoxServer } from '../index.js';
+
+test('getVMs assigns LXC node from the iterated node (not VM payload)', async () => {
+  const server = new ProxmoxServer();
+
+  server.proxmoxRequest = async (endpoint) => {
+    if (endpoint === '/nodes') {
+      return [{ node: 'pve1' }];
+    }
+    if (endpoint === '/nodes/pve1/lxc') {
+      return [
+        { vmid: '200', name: 'ct200', status: 'running', node: 'wrong-node' },
+      ];
+    }
+    throw new Error(`Unexpected endpoint in test: ${endpoint}`);
+  };
+
+  const result = await server.getVMs(null, 'lxc');
+  const text = result?.content?.[0]?.text ?? '';
+
+  assert.match(text, /Node:\s+pve1/);
+  assert.doesNotMatch(text, /wrong-node/);
+});
+


### PR DESCRIPTION
Fixes LXC node attribution when aggregating containers across nodes by always using the iterated node name (not a potentially stale/incorrect VM payload field).

Also:
- Makes "index.js" import-safe by only starting the server when executed directly.
- Adds a lightweight unit test using Node's built-in test runner.

This is intended as a minimal, reviewable alternative to PR #2 (which mixes the bugfix with a TS migration and other unrelated changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ProxmoxServer class is now exported as the default module export for external use.

* **Bug Fixes**
  * Fixed VM node assignment to accurately identify which cluster node each virtual machine belongs to when aggregating data.

* **Tests**
  * Added test case to validate VM node assignment accuracy.

* **Chores**
  * Added automated test script to package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->