### PR TITLE
Fix misleading "Failed to connect" for HTTP 596 node-case mismatches

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ try {
   console.error('Warning: Could not load .env file:', error.message);
 }
 
-class ProxmoxServer {
+export class ProxmoxServer {
   constructor() {
     this.server = new Server(
       {
@@ -59,7 +59,11 @@ class ProxmoxServer {
     this.httpsAgent = new https.Agent({
       rejectUnauthorized: false
     });
-    
+
+    // Inject fetch on the instance so tests can override it without touching
+    // the module-level import. Production code always uses node-fetch.
+    this.fetch = fetch;
+
     this.setupToolHandlers();
   }
 
@@ -140,10 +144,56 @@ class ProxmoxServer {
     }
 
     try {
-      const response = await fetch(url, options);
+      const response = await this.fetch(url, options);
 
       if (!response.ok) {
         const errorText = await response.text();
+
+        // Helpful error when pveproxy returns 596 for a node-scoped endpoint.
+        // 596 is Proxmox's proxy-failure umbrella code. Its most common trigger
+        // for callers is a node-name mismatch — Proxmox's cluster-node lookup is
+        // a case-sensitive Perl hash lookup (see pve-cluster/src/PVE/Cluster.pm
+        // :: check_node_exists / remote_node_ip). When the name we pass is not
+        // a cluster member, pveproxy cannot forward the request and emits 596.
+        // Authoritative explanation:
+        // https://forum.proxmox.com/threads/http-596-error-when-trying-to-use-the-api.102268/
+        if (response.status === 596) {
+          const nodeMatch = endpoint.match(/^\/nodes\/([^\/]+)/);
+          if (nodeMatch && endpoint !== '/nodes') {
+            const badName = nodeMatch[1];
+            try {
+              const nodesResp = await this.fetch(`${baseUrl}/nodes`, {
+                method: 'GET', headers, agent: this.httpsAgent,
+              });
+              if (nodesResp.ok) {
+                const nodesBody = JSON.parse(await nodesResp.text());
+                const known = (nodesBody.data || []).map((n) => n.node);
+                const canonical = known.find(
+                  (n) => n.toLowerCase() === badName.toLowerCase()
+                );
+                if (canonical && canonical !== badName) {
+                  throw new Error(
+                    `Proxmox returned 596 proxying to node "${badName}". ` +
+                    `Node name does not match a cluster member ` +
+                    `(lookup is case-sensitive). ` +
+                    `Did you mean "${canonical}"? ` +
+                    `Known nodes: ${known.join(', ')}.`
+                  );
+                }
+                throw new Error(
+                  `Proxmox returned 596 proxying to node "${badName}". ` +
+                  `The node is unknown to the cluster. ` +
+                  `Known nodes: ${known.join(', ')}. ` +
+                  `Other 596 causes include proxy timeouts and cert issues.`
+                );
+              }
+            } catch (lookupErr) {
+              if (lookupErr.message.startsWith('Proxmox returned 596')) throw lookupErr;
+              // Fall through to the generic error below if /nodes also fails.
+            }
+          }
+        }
+
         throw new Error(`Proxmox API error: ${response.status} - ${errorText}`);
       }
 
@@ -158,7 +208,19 @@ class ProxmoxServer {
       if (error.name === 'SyntaxError') {
         throw new Error(`Failed to parse Proxmox API response: ${error.message}`);
       }
-      throw new Error(`Failed to connect to Proxmox: ${error.message}`);
+      // Only wrap as "connection error" for genuine network-layer failures.
+      // Proxmox API errors (401/403/404/596/etc.) already carry the correct
+      // semantics in error.message and should pass through unchanged.
+      const isNetworkError =
+        ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'ECONNRESET', 'EHOSTUNREACH']
+          .includes(error.code) ||
+        error.name === 'FetchError' ||
+        (error.name === 'TypeError' && /fetch failed/i.test(error.message));
+      if (isNetworkError) {
+        throw new Error(`Failed to connect to Proxmox: ${error.message}`);
+      }
+      // Re-throw so callers see the real error (Proxmox API, parse, etc.).
+      throw error;
     }
   }
 
@@ -3144,5 +3206,11 @@ class ProxmoxServer {
   }
 }
 
-const server = new ProxmoxServer();
-server.run().catch(console.error);
+// Only start the server when this module is executed directly.
+// Import-safe so test files can construct ProxmoxServer without triggering a
+// stdio transport. (Pattern matches PR #4; included here to make the new
+// test/proxmoxRequest.test.js file self-contained.)
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = new ProxmoxServer();
+  server.run().catch(console.error);
+}

--- a/index.js
+++ b/index.js
@@ -183,16 +183,18 @@ export class ProxmoxServer {
                     `Known nodes: ${known.join(', ')}.`
                   );
                 }
-                if (canonical && canonical === badName) {
-                  // The node name is correct; 596 came from something else
-                  // (proxy timeout, cert issue on target node, transient).
+                if (canonical === badName) {
+                  // Exact match on a known cluster member, but still 596 — the
+                  // node exists and pveproxy still failed to proxy to it.
+                  // Likely proxy timeout, cert mismatch for that node's
+                  // pve-ssl.pem, or a transient forwarded-request failure.
                   // Do not emit a misleading "unknown node" hint.
                   throw new Error(
                     `Proxmox returned 596 proxying to node "${badName}". ` +
-                    `The node exists in the cluster, so this is likely a ` +
-                    `proxy-side issue (timeout, certificate, or transient ` +
-                    `upstream failure). See ` +
-                    `https://forum.proxmox.com/threads/http-596-error-when-trying-to-use-the-api.102268/`
+                    `The node is a known cluster member; the 596 likely ` +
+                    `indicates a proxy timeout, certificate issue, or ` +
+                    `forwarded-request failure. ` +
+                    `See https://forum.proxmox.com/threads/http-596-error-when-trying-to-use-the-api.102268/`
                   );
                 }
                 throw new Error(
@@ -3226,8 +3228,7 @@ export class ProxmoxServer {
 
 // Only start the server when this module is executed directly.
 // Import-safe so test files can construct ProxmoxServer without triggering a
-// stdio transport. (Pattern matches PR #4; included here to make the new
-// test/proxmoxRequest.test.js file self-contained.)
+// stdio transport.
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const server = new ProxmoxServer();
   server.run().catch(console.error);

--- a/index.js
+++ b/index.js
@@ -159,11 +159,14 @@ export class ProxmoxServer {
         // https://forum.proxmox.com/threads/http-596-error-when-trying-to-use-the-api.102268/
         if (response.status === 596) {
           const nodeMatch = endpoint.match(/^\/nodes\/([^\/]+)/);
-          if (nodeMatch && endpoint !== '/nodes') {
+          if (nodeMatch) {
             const badName = nodeMatch[1];
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 5000);
             try {
               const nodesResp = await this.fetch(`${baseUrl}/nodes`, {
                 method: 'GET', headers, agent: this.httpsAgent,
+                signal: controller.signal,
               });
               if (nodesResp.ok) {
                 const nodesBody = JSON.parse(await nodesResp.text());
@@ -180,6 +183,18 @@ export class ProxmoxServer {
                     `Known nodes: ${known.join(', ')}.`
                   );
                 }
+                if (canonical && canonical === badName) {
+                  // The node name is correct; 596 came from something else
+                  // (proxy timeout, cert issue on target node, transient).
+                  // Do not emit a misleading "unknown node" hint.
+                  throw new Error(
+                    `Proxmox returned 596 proxying to node "${badName}". ` +
+                    `The node exists in the cluster, so this is likely a ` +
+                    `proxy-side issue (timeout, certificate, or transient ` +
+                    `upstream failure). See ` +
+                    `https://forum.proxmox.com/threads/http-596-error-when-trying-to-use-the-api.102268/`
+                  );
+                }
                 throw new Error(
                   `Proxmox returned 596 proxying to node "${badName}". ` +
                   `The node is unknown to the cluster. ` +
@@ -189,7 +204,10 @@ export class ProxmoxServer {
               }
             } catch (lookupErr) {
               if (lookupErr.message.startsWith('Proxmox returned 596')) throw lookupErr;
-              // Fall through to the generic error below if /nodes also fails.
+              // Fall through to the generic error below if /nodes also fails
+              // (non-ok response, parse failure, or abort/timeout).
+            } finally {
+              clearTimeout(timeoutId);
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "dev": "node --watch index.js"
+    "dev": "node --watch index.js",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.4.0",

--- a/test/proxmoxRequest.test.js
+++ b/test/proxmoxRequest.test.js
@@ -1,0 +1,200 @@
+// test/proxmoxRequest.test.js
+//
+// Unit tests for `proxmoxRequest`'s error-handling behavior on node-scoped
+// endpoints. Uses Node's built-in test runner (`node --test`) and
+// instance-level fetch injection (`server.fetch = ...`). No new deps.
+//
+// Style matches the existing tests added in PR #4 (test/getVMs.lxc-node.test.js)
+// and PR #5 (test/validation.identifiers.test.js).
+//
+// Node names (Pve1/Pve2/Pve3) and VMID (100) are illustrative only.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ProxmoxServer } from '../index.js';
+
+function createServer() {
+  process.env.PROXMOX_HOST ??= 'example.invalid';
+  process.env.PROXMOX_TOKEN_VALUE ??= 'test-token';
+  return new ProxmoxServer();
+}
+
+function mockResponse({ ok, status, bodyText }) {
+  return {
+    ok,
+    status,
+    text: async () => bodyText,
+  };
+}
+
+// --- Part 1: narrow the "Failed to connect" wrap ------------------------
+
+test('proxmoxRequest: genuine network error (ECONNREFUSED) still wraps as "Failed to connect"', async () => {
+  const server = createServer();
+  server.fetch = async () => {
+    const err = new Error('connect ECONNREFUSED 127.0.0.1:8006');
+    err.code = 'ECONNREFUSED';
+    throw err;
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/version'),
+    (err) => err.message.startsWith('Failed to connect to Proxmox:') &&
+            /ECONNREFUSED/.test(err.message)
+  );
+});
+
+test('proxmoxRequest: 401 Proxmox API error is NOT wrapped as "Failed to connect"', async () => {
+  const server = createServer();
+  server.fetch = async () => mockResponse({
+    ok: false, status: 401, bodyText: 'authentication failure',
+  });
+
+  await assert.rejects(
+    server.proxmoxRequest('/version'),
+    (err) => err.message.startsWith('Proxmox API error: 401') &&
+            !err.message.startsWith('Failed to connect to Proxmox:')
+  );
+});
+
+test('proxmoxRequest: 403 Proxmox API error is NOT wrapped as "Failed to connect"', async () => {
+  const server = createServer();
+  server.fetch = async () => mockResponse({
+    ok: false, status: 403, bodyText: 'permission check failed',
+  });
+
+  await assert.rejects(
+    server.proxmoxRequest('/nodes/Pve1/lxc/100/status/current'),
+    (err) => err.message.startsWith('Proxmox API error: 403') &&
+            !err.message.startsWith('Failed to connect to Proxmox:')
+  );
+});
+
+// --- Part 2: node-path 596 hint — over-trigger guards -------------------
+
+test('proxmoxRequest: 596 on a non-/nodes endpoint is NOT wrapped and no hint is emitted', async () => {
+  const server = createServer();
+  let nodesListingRequested = false;
+  server.fetch = async (url) => {
+    if (url.endsWith('/api2/json/nodes')) nodesListingRequested = true;
+    return mockResponse({ ok: false, status: 596, bodyText: 'proxy timeout' });
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/cluster/resources'),
+    (err) => err.message.startsWith('Proxmox API error: 596') &&
+            !/Did you mean/.test(err.message) &&
+            !err.message.startsWith('Failed to connect to Proxmox:')
+  );
+  assert.equal(nodesListingRequested, false, 'hint logic must not probe /nodes for non-node endpoints');
+});
+
+test('proxmoxRequest: 596 on /nodes itself (the listing) does NOT trigger the hint recursion', async () => {
+  // Edge case: the endpoint `/nodes` matches /^\/nodes\/([^\/]+)/ only if a
+  // sub-path is present. Verify the hint is correctly skipped for the bare
+  // /nodes listing so we don't produce an infinite loop on 596.
+  const server = createServer();
+  let callCount = 0;
+  server.fetch = async () => {
+    callCount += 1;
+    return mockResponse({ ok: false, status: 596, bodyText: 'proxy timeout' });
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/nodes'),
+    (err) => err.message.startsWith('Proxmox API error: 596')
+  );
+  assert.equal(callCount, 1, 'the hint path must not re-fetch /nodes when the request itself is /nodes');
+});
+
+// --- Part 2: node-path 596 hint — happy paths ---------------------------
+
+test('proxmoxRequest: 596 on /nodes/{case-variant}/... suggests canonical case', async () => {
+  const server = createServer();
+  const calls = [];
+  server.fetch = async (url) => {
+    calls.push(url);
+    if (url.endsWith('/api2/json/nodes')) {
+      return mockResponse({
+        ok: true, status: 200,
+        bodyText: JSON.stringify({ data: [{ node: 'Pve1' }, { node: 'Pve2' }] }),
+      });
+    }
+    return mockResponse({ ok: false, status: 596, bodyText: "no such cluster node 'pve1'" });
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/nodes/pve1/lxc/100/status/current'),
+    (err) => /Did you mean "Pve1"\?/.test(err.message) &&
+            /Known nodes: Pve1, Pve2/.test(err.message) &&
+            /case-sensitive/.test(err.message)
+  );
+  assert.equal(calls.length, 2, 'exactly one main call + one /nodes probe');
+  assert.match(calls[0], /\/nodes\/pve1\/lxc\/100\/status\/current$/);
+  assert.match(calls[1], /\/api2\/json\/nodes$/);
+});
+
+test('proxmoxRequest: 596 on /nodes/{unknown}/... lists known nodes (no false suggestion)', async () => {
+  const server = createServer();
+  const calls = [];
+  server.fetch = async (url) => {
+    calls.push(url);
+    if (url.endsWith('/api2/json/nodes')) {
+      return mockResponse({
+        ok: true, status: 200,
+        bodyText: JSON.stringify({
+          data: [{ node: 'Pve1' }, { node: 'Pve2' }, { node: 'Pve3' }],
+        }),
+      });
+    }
+    return mockResponse({
+      ok: false, status: 596, bodyText: "no such cluster node 'completely-fake'",
+    });
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/nodes/completely-fake/lxc/100/status/current'),
+    (err) => /The node is unknown to the cluster/.test(err.message) &&
+            /Known nodes: Pve1, Pve2, Pve3/.test(err.message) &&
+            !/Did you mean/.test(err.message)
+  );
+  assert.equal(calls.length, 2, 'exactly one main call + one /nodes probe');
+  assert.match(calls[0], /\/nodes\/completely-fake\/lxc\/100\/status\/current$/);
+  assert.match(calls[1], /\/api2\/json\/nodes$/);
+});
+
+test('proxmoxRequest: 596 on /nodes/... when /nodes listing itself fails, falls through to raw 596', async () => {
+  const server = createServer();
+  server.fetch = async (url) => {
+    if (url.endsWith('/api2/json/nodes')) {
+      return mockResponse({ ok: false, status: 500, bodyText: 'internal' });
+    }
+    return mockResponse({ ok: false, status: 596, bodyText: "no such cluster node 'pve1'" });
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/nodes/pve1/lxc/100/status/current'),
+    (err) => err.message.startsWith('Proxmox API error: 596') &&
+            !/Did you mean/.test(err.message) &&
+            !/Known nodes/.test(err.message) &&
+            !/\b500\b/.test(err.message) &&
+            !/internal/i.test(err.message)
+  );
+});
+
+test('proxmoxRequest: 596 on /nodes/... when /nodes returns malformed JSON, falls through to raw 596', async () => {
+  const server = createServer();
+  server.fetch = async (url) => {
+    if (url.endsWith('/api2/json/nodes')) {
+      return mockResponse({ ok: true, status: 200, bodyText: 'not json {' });
+    }
+    return mockResponse({ ok: false, status: 596, bodyText: "no such cluster node 'pve1'" });
+  };
+  await assert.rejects(
+    server.proxmoxRequest('/nodes/pve1/lxc/100/status/current'),
+    (err) => err.message.startsWith('Proxmox API error: 596') &&
+            !/Did you mean/.test(err.message) &&
+            !/Failed to parse/.test(err.message)
+  );
+});

--- a/test/proxmoxRequest.test.js
+++ b/test/proxmoxRequest.test.js
@@ -4,9 +4,6 @@
 // endpoints. Uses Node's built-in test runner (`node --test`) and
 // instance-level fetch injection (`server.fetch = ...`). No new deps.
 //
-// Style matches the existing tests added in PR #4 (test/getVMs.lxc-node.test.js)
-// and PR #5 (test/validation.identifiers.test.js).
-//
 // Node names (Pve1/Pve2/Pve3) and VMID (100) are illustrative only.
 
 import test from 'node:test';
@@ -196,5 +193,29 @@ test('proxmoxRequest: 596 on /nodes/... when /nodes returns malformed JSON, fall
     (err) => err.message.startsWith('Proxmox API error: 596') &&
             !/Did you mean/.test(err.message) &&
             !/Failed to parse/.test(err.message)
+  );
+});
+
+test('proxmoxRequest: 596 on /nodes/{exact-match}/... emits proxy-side hint, no "Did you mean"', async () => {
+  // Node name exactly matches a known cluster node, yet 596 still came back —
+  // the cause is NOT a name mismatch (proxy timeout, cert, transient upstream).
+  // Must not emit a misleading "unknown node" / "Did you mean" hint.
+  const server = createServer();
+  server.fetch = async (url) => {
+    if (url.endsWith('/api2/json/nodes')) {
+      return mockResponse({
+        ok: true, status: 200,
+        bodyText: JSON.stringify({ data: [{ node: 'Pve1' }, { node: 'Pve2' }] }),
+      });
+    }
+    return mockResponse({ ok: false, status: 596, bodyText: 'upstream connection refused' });
+  };
+
+  await assert.rejects(
+    server.proxmoxRequest('/nodes/Pve1/lxc/100/status/current'),
+    (err) => /The node exists in the cluster/.test(err.message) &&
+            /proxy-side issue/.test(err.message) &&
+            !/Did you mean/.test(err.message) &&
+            !/unknown to the cluster/.test(err.message)
   );
 });

--- a/test/proxmoxRequest.test.js
+++ b/test/proxmoxRequest.test.js
@@ -196,26 +196,28 @@ test('proxmoxRequest: 596 on /nodes/... when /nodes returns malformed JSON, fall
   );
 });
 
-test('proxmoxRequest: 596 on /nodes/{exact-match}/... emits proxy-side hint, no "Did you mean"', async () => {
-  // Node name exactly matches a known cluster node, yet 596 still came back —
-  // the cause is NOT a name mismatch (proxy timeout, cert, transient upstream).
-  // Must not emit a misleading "unknown node" / "Did you mean" hint.
+test('proxmoxRequest: 596 on /nodes/{exact-case-match}/... surfaces generic 596 (not "unknown")', async () => {
   const server = createServer();
+  const calls = [];
   server.fetch = async (url) => {
+    calls.push(url);
     if (url.endsWith('/api2/json/nodes')) {
       return mockResponse({
         ok: true, status: 200,
         bodyText: JSON.stringify({ data: [{ node: 'Pve1' }, { node: 'Pve2' }] }),
       });
     }
-    return mockResponse({ ok: false, status: 596, bodyText: 'upstream connection refused' });
+    // Pve1 is a real cluster node, but this specific request still returns 596 —
+    // plausible causes: proxy timeout, cert issue, forwarded-request failure.
+    return mockResponse({ ok: false, status: 596, bodyText: 'proxy timeout' });
   };
 
   await assert.rejects(
     server.proxmoxRequest('/nodes/Pve1/lxc/100/status/current'),
-    (err) => /The node exists in the cluster/.test(err.message) &&
-            /proxy-side issue/.test(err.message) &&
+    (err) => /known cluster member/i.test(err.message) &&
+            /proxy timeout|cert issue|forwarded-request/i.test(err.message) &&
             !/Did you mean/.test(err.message) &&
             !/unknown to the cluster/.test(err.message)
   );
+  assert.equal(calls.length, 2, 'exactly one main call + one /nodes probe');
 });

--- a/test/proxmoxRequest.test.js
+++ b/test/proxmoxRequest.test.js
@@ -208,14 +208,14 @@ test('proxmoxRequest: 596 on /nodes/{exact-case-match}/... surfaces generic 596 
       });
     }
     // Pve1 is a real cluster node, but this specific request still returns 596 —
-    // plausible causes: proxy timeout, cert issue, forwarded-request failure.
+    // plausible causes: proxy timeout, certificate issue, forwarded-request failure.
     return mockResponse({ ok: false, status: 596, bodyText: 'proxy timeout' });
   };
 
   await assert.rejects(
     server.proxmoxRequest('/nodes/Pve1/lxc/100/status/current'),
     (err) => /known cluster member/i.test(err.message) &&
-            /proxy timeout|cert issue|forwarded-request/i.test(err.message) &&
+            /proxy timeout|certificate issue|forwarded-request/i.test(err.message) &&
             !/Did you mean/.test(err.message) &&
             !/unknown to the cluster/.test(err.message)
   );


### PR DESCRIPTION
## Summary

Fixes #8.

Two-part fix:
1. **Narrow the "Failed to connect to Proxmox" error wrap** in `proxmoxRequest` to genuine network-layer errors only (`ECONNREFUSED`, `ETIMEDOUT`, `ENOTFOUND`, `ECONNRESET`, `EHOSTUNREACH`). Proxmox API errors (401/403/404/596) now surface with their real meaning instead of being mis-labelled as connection failures.
2. **Helpful error for HTTP 596 on node-scoped endpoints.** When Proxmox's pveproxy returns 596 for a `/nodes/{name}/...` request, the server now cross-references against the known cluster nodes and suggests the canonical case. If no case-insensitive match exists, it lists the known nodes.

No breaking changes to the tool interface or the success path. Only the error-message strings change on specific failure paths.

## Root cause

See #8 for full analysis. In one paragraph:

- `validateNodeName` accepts any case via the regex `^[a-zA-Z0-9\-_]+$`.
- Proxmox's cluster-node lookup (`pve-cluster`, `Cluster.pm::check_node_exists`, `Cluster.pm::remote_node_ip`) is a Perl hash-key lookup that is case-sensitive by language spec.
- On mismatch, pveproxy returns HTTP 596 (its proxy-failure umbrella code) with body `no such cluster node '<name>'`.
- `proxmoxRequest`'s catch re-wraps every error as `Failed to connect to Proxmox`, which is wrong for server-side errors — fetch succeeded, Proxmox responded, there was no connection failure.

Proxmox Staff confirmation of 596 semantics: https://forum.proxmox.com/threads/http-596-error-when-trying-to-use-the-api.102268/

## Changes

- `index.js`
  - `proxmoxRequest`:
    - Extract `isNetworkError` check using Node's canonical error codes before deciding whether to wrap.
    - For HTTP 596 on `/nodes/{name}/...` URLs, attempt a one-shot `/nodes` list and return a helpful three-branch error: "Did you mean …?" (case/FQDN variant), "known cluster member; proxy timeout / certificate / forwarded-request failure" (exact case match, 596 from some other cause), or "Known nodes: …" (unknown node). Link to the Proxmox forum explanation included.
- `test/proxmoxRequest.test.js` (new):
  - Network-error passthrough (1 test): ECONNREFUSED still wraps as "Failed to connect".
  - API-error passthrough (2 tests): 401 and 403 no longer masked as "Failed to connect".
  - 596 over-trigger guards (2 tests): non-/nodes 596 and bare /nodes 596 produce no hint and no recursion.
  - 596 node-hint three branches (3 tests): case-variant → "Did you mean …"; unknown node → "Known nodes: …"; exact-case match → "known cluster member; proxy-side issue". All three assert exactly one main + one /nodes probe fetch.
  - 596 node-hint fall-through (2 tests): /nodes lookup returning 500 or malformed JSON surfaces raw 596 without leaking probe failure details.

## Test plan

- `node --test test/*.test.js`
- Manual reproduction on a real single-node PVE 8.x cluster: confirmed 596 → helpful error.

## Notes

Draft and tests developed with AI-assisted tooling; all changes reviewed locally against a fresh clone of `origin/main@1d7e9c2`.

## Backward compatibility

- **Tool interface:** unchanged.
- **Success path:** unchanged.
- **Failure paths:**
  - 596 on a `/nodes/...` URL: new, more helpful error message. Previous message was `Failed to connect to Proxmox: Proxmox API error: 596 - <body>`.
  - 401/403/404 on any URL: now surfaces as `Proxmox API error: 401 - <body>` instead of `Failed to connect to Proxmox: Proxmox API error: 401 - ...`. Callers that grep on the old "Failed to connect" substring for non-network errors will break — but this substring was semantically wrong, so the breakage surfaces correct information.
  - Genuine network failure (`ECONNREFUSED` etc.): unchanged message.

Any caller relying on the old, misleading wrap for non-network errors was relying on an incorrect behavior. The change is a correctness fix.

## Style / scope decisions

- Kept the `rejectUnauthorized: false` behavior out of scope. That's a separate issue (#6) with its own fix trajectory.
- Did not refactor the 20+ `safeNode` call sites. The fix lives entirely in `proxmoxRequest`, which they all funnel through.
- Did not add case-normalization in `validateNodeName`. Auto-normalization would mask legitimate "unknown node" errors. Surfacing the error with a helpful suggestion preserves the signal while fixing the UX.

## Related

- Closes #8
- Adjacent: #6 (TLS hardening — separate fix)
- Adjacent: #4 / #5 / #7 (maintainer's own input-validation hardening — this PR doesn't touch the validators they're adding)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages for invalid node references with suggestions for correct node names when applicable
  * Enhanced error classification to distinguish network connectivity failures from Proxmox API errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

